### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,8 +977,12 @@ os.environ['VLLM_WORKER_MULTIPROC_METHOD'] = 'spawn'
 def prepare_inputs_for_vllm(messages, processor):
     text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
     # qwen_vl_utils 0.0.14+ reqired
-    image_inputs, video_inputs, video_kwargs = process_vision_info(messages,
-            image_patch_size=processor.image_processor.patch_size, return_video_kwargs=True, return_video_metadata=True)
+    image_inputs, video_inputs, video_kwargs = process_vision_info(
+        messages,
+        image_patch_size=processor.image_processor.patch_size,
+        return_video_kwargs=True,
+        return_video_metadata=True
+    )
     print(f"video_kwargs: {video_kwargs}")
 
     mm_data = {}
@@ -995,19 +999,6 @@ def prepare_inputs_for_vllm(messages, processor):
 
 
 if __name__ == '__main__':
-    # messages = [
-    #     {
-    #         "role": "user",
-    #         "content": [
-    #             {
-    #                 "type": "video",
-    #                 "video": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen2-VL/space_woaudio.mp4",
-    #             },
-    #             {"type": "text", "text": "这段视频有多长"},
-    #         ],
-    #     }
-    # ]
-
     messages = [
         {
             "role": "user",
@@ -1021,14 +1012,17 @@ if __name__ == '__main__':
         }
     ]
 
-    # TODO: change to your own checkpoint path
     checkpoint_path = "Qwen/Qwen3-VL-235B-A22B-Instruct"
     processor = AutoProcessor.from_pretrained(checkpoint_path)
     inputs = [prepare_inputs_for_vllm(message, processor) for message in [messages]]
 
     llm = LLM(
-        model=checkpoint_path, trust_remote_code=True, 
-      	gpu_memory_utilization=0.70, enforce_eager=False,
+        model=checkpoint_path,
+        trust_remote_code=True,
+        gpu_memory_utilization=0.97,
+        enforce_eager=False,
+        max_model_len=8192,
+        max_num_seqs=8,
         tensor_parallel_size=torch.cuda.device_count(),
         seed=0
     )


### PR DESCRIPTION
### **Fix: Resolve OOM Errors for Qwen3-VL Inference with vLLM**

Resolves `CUDA out of memory` errors during vLLM initialization for the `Qwen3-VL-235B` model. The previous configuration failed due to insufficient memory allocation, even on 8x H100 GPUs.

**Changes:**

* **Increased GPU Utilization:** Upped `gpu_memory_utilization` from `0.70` to `0.97` to allow vLLM to use more VRAM.
* **Set Engine Limits:** Explicitly configured `max_model_len=8192` and `max_num_seqs=8`. The previous high default values (e.g., `max_num_seqs=1024`) caused excessive memory pre-allocation during sampler warmup.

**Validation:**

* Tested and confirmed working in a Docker environment with 8x NVIDIA H100 GPUs. The model now initializes and runs inference successfully.