### PR TITLE
Update doc for vLLM deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,19 +838,16 @@ cd docker && bash run_web_demo.sh -c /your/path/to/qwen3vl/weight --port 8881
 
 ## Deployment
 
-We recommend using vLLM for fast Qwen3-VL deployment and inference. You need to install `vllm>0.10.2` to enable Qwen3-VL support. You can also use our [official docker image](#-docker).
+We recommend using vLLM for fast Qwen3-VL deployment and inference. You need to install `vllm>=0.11.0` to enable Qwen3-VL support. You can also use our [official docker image](#-docker).
 
 You can also check [vLLM official documentation](https://docs.vllm.ai/en/latest/serving/multimodal_inputs.html) for more details about online serving and offline inference.
 
 ### Installation
 ```bash
-pip install git+https://github.com/huggingface/transformers
 pip install accelerate
 pip install qwen-vl-utils==0.0.14
-# pip install 'vllm>0.10.2' # If this is not working use the below one. 
-uv pip install -U vllm \
-    --torch-backend=auto \
-    --extra-index-url https://wheels.vllm.ai/nightly
+# Install the latest version of vLLM 'vllm>=0.11.0'
+uv pip install -U vllm
 ```
 
 ### Online Serving
@@ -860,19 +857,13 @@ The following launch command is applicable to H100/H200; for more efficient depl
 
 * vLLM server
 ```shell
-# FP8 requires NVIDIA H100+ and CUDA 12+
-python -m vllm.entrypoints.openai.api_server \
-  --model Qwen/Qwen3-VL-235B-A22B-Instruct\
-  --served-model-name Qwen/Qwen3-VL-235B-A22B-Instruct \
+# Efficient inference with FP8 checkpoint
+# Requires NVIDIA H100+ and CUDA 12+
+vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct-FP8 \
   --tensor-parallel-size 8 \
   --mm-encoder-tp-mode data \
   --enable-expert-parallel \
-  --host 0.0.0.0 \
-  --port 22002 \
-  --dtype bfloat16 \
-  --gpu-memory-utilization 0.70 \
-  --quantization fp8 \
-  --distributed-executor-backend mp
+  --async-scheduling
 ```
 * SGLang server
 ```

--- a/README.md
+++ b/README.md
@@ -863,7 +863,9 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct-FP8 \
   --tensor-parallel-size 8 \
   --mm-encoder-tp-mode data \
   --enable-expert-parallel \
-  --async-scheduling
+  --async-scheduling \
+  --host 0.0.0.0 \
+  --port 22002
 ```
 * SGLang server
 ```

--- a/README.md
+++ b/README.md
@@ -840,7 +840,7 @@ cd docker && bash run_web_demo.sh -c /your/path/to/qwen3vl/weight --port 8881
 
 We recommend using vLLM for fast Qwen3-VL deployment and inference. You need to install `vllm>=0.11.0` to enable Qwen3-VL support. You can also use our [official docker image](#-docker).
 
-You can also check [vLLM official documentation](https://docs.vllm.ai/en/latest/serving/multimodal_inputs.html) for more details about online serving and offline inference.
+Please check [vLLM official documentation](https://docs.vllm.ai/en/latest/serving/multimodal_inputs.html) for more details about online serving and offline inference for multimodal models.
 
 ### Installation
 ```bash
@@ -906,7 +906,7 @@ messages = [
 
 start = time.time()
 response = client.chat.completions.create(
-    model="Qwen/Qwen3-VL-235B-A22B-Instruct",
+    model="Qwen/Qwen3-VL-235B-A22B-Instruct-FP8",
     messages=messages,
     max_tokens=2048
 )
@@ -944,7 +944,7 @@ messages = [
 
 start = time.time()
 response = client.chat.completions.create(
-    model="Qwen/Qwen3-VL-235B-A22B-Instruct",
+    model="Qwen/Qwen3-VL-235B-A22B-Instruct-FP8",
     messages=messages,
     max_tokens=2048
 )
@@ -1020,16 +1020,14 @@ if __name__ == '__main__':
     ]
 
     # TODO: change to your own checkpoint path
-    checkpoint_path = "Qwen/Qwen3-VL-235B-A22B-Instruct"
+    checkpoint_path = "Qwen/Qwen3-VL-235B-A22B-Instruct-FP8"
     processor = AutoProcessor.from_pretrained(checkpoint_path)
     inputs = [prepare_inputs_for_vllm(message, processor) for message in [messages]]
 
     llm = LLM(
         model=checkpoint_path,
-        trust_remote_code=True,
-        gpu_memory_utilization=0.70,
-        enforce_eager=False,
-        quantization="fp8",
+        mm_encoder_tp_mode="data",
+        enable_expert_parallel=True,
         tensor_parallel_size=torch.cuda.device_count(),
         seed=0
     )


### PR DESCRIPTION
Since vLLM has released 0.11.0, there's no longer a need to install the nightly wheel.

I plan to also update the dockerfile but will leave that in a separate PR.