### PR TITLE
[fix] update docker base image to v0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -873,8 +873,10 @@ vllm serve Qwen/Qwen3-VL-235B-A22B-Instruct-FP8 \
 * SGLang server
 ```
 python -m sglang.launch_server \
-   --model-path Qwen/Qwen3-VL-235B-A22B-Instruct\
-   --tp 8 
+   --model-path Qwen/Qwen3-VL-235B-A22B-Instruct \
+   --host 0.0.0.0 \
+   --port 22002 \
+   --tp 8
 ```
 * Image Request Example
 ```python

--- a/docker/Dockerfile-qwen3vl-cu128
+++ b/docker/Dockerfile-qwen3vl-cu128
@@ -1,14 +1,12 @@
 # Dockerfile of qwenllm/qwenvl:qwen3vl-cu128
-FROM vllm/vllm-openai:nightly-7ed82d1974837957a3bfb6d576b9cffba24d31ae as base
+FROM vllm/vllm-openai:v0.11.0 as base
 ENTRYPOINT []
 
-# Install requirements
 RUN ln -sf /usr/bin/python3 /usr/bin/python &&  pip install --no-cache-dir \
     git+https://github.com/huggingface/transformers \
-    qwen-vl-utils==0.0.13 \
+    qwen-vl-utils==0.0.14 \
     torchcodec==0.7 \
-    gradio==5.46.1 \
-    gradio_client==1.13.1 \
+    gradio==5.49.1 \
     transformers-stream-generator==0.0.5 \
     accelerate
 


### PR DESCRIPTION
* 更新镜像到 vLLM 0.11.0 正式版本；
* 设置 SGLang host 和 port 保证测试用例可用。