### PR TITLE
[BUG FIX]Skip empty dataset names in data_list function for finetune

### DIFF
--- a/qwen-vl-finetune/qwenvl/data/__init__.py
+++ b/qwen-vl-finetune/qwenvl/data/__init__.py
@@ -45,6 +45,8 @@ def parse_sampling_rate(dataset_name):
 def data_list(dataset_names):
     config_list = []
     for dataset_name in dataset_names:
+        if not dataset_name:
+            continue
         sampling_rate = parse_sampling_rate(dataset_name)
         dataset_name = re.sub(r"%(\d+)$", "", dataset_name)
         if dataset_name in data_dict.keys():


### PR DESCRIPTION
when parsing dataset_use by split(',') in the finetune script, if there is only one dataset name("my_set%100"), the code will raise excepted valuError because of the empty string: https://github.com/QwenLM/Qwen3-VL/blob/599ce6104cab6e111f40a30e786561e41b9731ba/qwen-vl-finetune/qwenvl/data/data_processor.py#L250