### PR TITLE
Fix process_vision_info return type hint to support 2-tuple unpacking

### DIFF
--- a/qwen-vl-utils/src/qwen_vl_utils/vision_process.py
+++ b/qwen-vl-utils/src/qwen_vl_utils/vision_process.py
@@ -503,7 +503,7 @@ def process_vision_info(
     return_video_kwargs: bool = False,
     return_video_metadata: bool = False,
     image_patch_size: int = 14,
-) -> Tuple[Optional[List[Image.Image]], Optional[List[Union[torch.Tensor, List[Image.Image]]]], Optional[Dict[str, Any]]]:
+) -> Union[Tuple[Optional[List[Image.Image]], Optional[List[Union[torch.Tensor, List[Image.Image]]]]], Tuple[Optional[List[Image.Image]], Optional[List[Union[torch.Tensor, List[Image.Image]]]], Optional[Dict[str, Any]]]]:
 
     vision_infos = extract_vision_info(conversations)
     ## Read images or videos


### PR DESCRIPTION
Adjusted the function signature to strictly match runtime behavior, allowing the return type to be either a 2-tuple or a 3-tuple, stopping the IDE from complaining when only two values are unpacked