### PR TITLE
Refactor return type of process_vision_info function

### DIFF
--- a/qwen-vl-utils/src/qwen_vl_utils/vision_process.py
+++ b/qwen-vl-utils/src/qwen_vl_utils/vision_process.py
@@ -498,12 +498,18 @@ def extract_vision_info(conversations: Union[List[Dict[str, Any]], List[List[Dic
     return vision_infos
 
 
+ImageInputs = Optional[List[Image.Image]]
+VideoInputs = Optional[List[Union[torch.Tensor, List[Image.Image]]]]
+VideoKWArgs = Optional[Dict[str, Any]]
+ProcessVisionInfoReturnWithVideoKWArgs = Tuple[ImageInputs, VideoInputs, VideoKWArgs]
+ProcessVisionInfoReturnWithoutVideoKWArgs = Tuple[ImageInputs, VideoInputs]
+ProcessVisionInfoReturn = Union[ProcessVisionInfoReturnWithVideoKWArgs, ProcessVisionInfoReturnWithoutVideoKWArgs]
 def process_vision_info(
     conversations: Union[List[Dict[str, Any]], List[List[Dict[str, Any]]]],
     return_video_kwargs: bool = False,
     return_video_metadata: bool = False,
     image_patch_size: int = 14,
-) -> Tuple[Optional[List[Image.Image]], Optional[List[Union[torch.Tensor, List[Image.Image]]]], Optional[Dict[str, Any]]]:
+) -> ProcessVisionInfoReturn:
 
     vision_infos = extract_vision_info(conversations)
     ## Read images or videos


### PR DESCRIPTION
The current type doesn't acknowledge that it may return a pair, and so calling code expects a triple, causing "Too many values to unpack " warnings. This simply corrects the type.