### PR TITLE
Remove unseeded shuffle for DDP consistency

### DIFF
--- a/qwen-vl-finetune/qwenvl/data/data_processor.py
+++ b/qwen-vl-finetune/qwenvl/data/data_processor.py
@@ -292,7 +292,6 @@ class LazySupervisedDataset(Dataset):
 
         rank0_print(f"Total training samples: {len(list_data_dict)}")
 
-        random.shuffle(list_data_dict)  # Randomly shuffle the data for training
 
         rank0_print("Formatting inputs...Skip in lazy mode")
         processor = update_processor_pixels(processor, data_args)


### PR DESCRIPTION
Fixes #1947

This PR removes the unseeded `random.shuffle(list_data_dict)` in `qwen-vl-finetune/qwenvl/data/data_processor.py`.

In DDP training, each rank initializes its own dataset/data processor. Executing an unseeded shuffle independently per-rank can lead to inconsistent dataset ordering across ranks, which may violate `torch.utils.data.DistributedSampler`'s assumption that all ranks share the same dataset order, potentially causing duplicated or missing samples.

Removing this line keeps the dataset order deterministic/synchronized and lets the sampler handle shuffling and partitioning as intended.