### PR TITLE
Update attribute visual and language_model to qwen3-vl architecture

### DIFF
--- a/qwen-vl-finetune/qwenvl/train/train_qwen.py
+++ b/qwen-vl-finetune/qwenvl/train/train_qwen.py
@@ -65,26 +65,28 @@ def safe_save_model_for_hf_trainer(trainer: transformers.Trainer, output_dir: st
 
 
 def set_model(model_args, model):
+    visual = getattr(model, "visual", None) or getattr(model.model, "visual", None)
+    language_model = getattr(model, "language_model", None) or getattr(model.model, "language_model", None)
     if model_args.tune_mm_vision:
-        for n, p in model.visual.named_parameters():
+        for n, p in visual.named_parameters():
             p.requires_grad = True
     else:
-        for n, p in model.visual.named_parameters():
+        for n, p in visual.named_parameters():
             p.requires_grad = False
 
     if model_args.tune_mm_mlp:
-        for n, p in model.visual.merger.named_parameters():
+        for n, p in visual.merger.named_parameters():
             p.requires_grad = True
     else:
-        for n, p in model.visual.merger.named_parameters():
+        for n, p in visual.merger.named_parameters():
             p.requires_grad = False
 
     if model_args.tune_mm_llm:
-        for n, p in model.language_model.named_parameters():
+        for n, p in language_model.named_parameters():
             p.requires_grad = True
         model.lm_head.requires_grad = True
     else:
-        for n, p in model.language_model.named_parameters():
+        for n, p in language_model.named_parameters():
             p.requires_grad = False
         model.lm_head.requires_grad = False
 
@@ -180,7 +182,8 @@ def train(attn_implementation="flash_attention_2"):
         set_model(model_args, model)
 
         if torch.distributed.get_rank() == 0:
-            model.visual.print_trainable_parameters()
+            visual = getattr(model, "visual", None) or getattr(model.model, "visual", None)
+            visual.print_trainable_parameters()
             model.model.print_trainable_parameters()
     
     data_module = make_supervised_data_module(processor, data_args=data_args)


### PR DESCRIPTION
## Fix: Qwen3-VL visual encoder and language_model attribute path in `set_model`

### Problem
When training with Qwen3-VL models, the following error occurred:
```
AttributeError: 'Qwen3VLForConditionalGeneration' object has no attribute 'visual'
```
The `set_model` function accessed `model.visual`, which was valid for Qwen2-VL but is not compatible with Qwen3-VL's architecture, where the visual encoder is nested under `model.model.visual`. Same for language_model.

### Fix
Updated the attribute access in `set_model` to correctly resolve the visual encoder for Qwen3-VL:
```python
# Before
for n, p in model.visual.named_parameters():

# After
visual = getattr(model, "visual", None) or getattr(model.model, "visual", None)
for n, p in visual.named_parameters():
```
This change is backward compatible and works for both Qwen2-VL and Qwen3-VL.

### Tested with
- `Qwen/Qwen3-VL-4B-Instruct`
- `Qwen3VLForConditionalGeneration`