### PR TITLE
Fix torchvision video frame indices offset

### DIFF
--- a/qwen-vl-utils/src/qwen_vl_utils/vision_process.py
+++ b/qwen-vl-utils/src/qwen_vl_utils/vision_process.py
@@ -216,6 +216,16 @@ def _read_video_torchvision(
     sample_fps = nframes / max(total_frames, 1e-6) * video_fps
     video = video[idx]
 
+    # Make frame indices absolute to the original video, matching decord/torchcodec.
+    # torchvision.read_video returns a clipped segment, so sampled idx is relative
+    # to that clip. We add the start offset computed from video_start and video_fps.
+    video_start = ele.get("video_start", None)
+    if video_start is not None:
+        start_offset = math.ceil(max(video_start, 0.0) * video_fps)
+    else:
+        start_offset = 0
+    idx = (idx + start_offset).tolist()
+
     video_metadata = dict(
         fps=video_fps,
         frames_indices=idx,

--- a/qwen-vl-utils/tests/test_torchvision_frame_indices.py
+++ b/qwen-vl-utils/tests/test_torchvision_frame_indices.py
@@ -1,0 +1,60 @@
+"""Regression test: torchvision backend frames_indices must be absolute.
+
+See https://github.com/QwenLM/Qwen3-VL/issues/2085
+"""
+
+import types
+
+import pytest
+import torch
+
+
+def _make_fake_torchvision_io(total_frames=100, fps=25.0):
+    """Return a fake torchvision.io module whose read_video returns zeros."""
+
+    def fake_read_video(path, start_pts=0.0, end_pts=None, pts_unit="sec", output_format="TCHW"):
+        s = int(start_pts * fps) if start_pts else 0
+        e = int(end_pts * fps) if end_pts is not None else total_frames
+        e = min(e, total_frames)
+        clip = max(e - s, 0)
+        video = torch.zeros(clip, 3, 8, 8, dtype=torch.uint8)
+        info = {"video_fps": fps}
+        return video, None, info
+
+    mod = types.ModuleType("torchvision.io")
+    mod.read_video = fake_read_video
+    return mod
+
+
+@pytest.fixture()
+def _patch_io(monkeypatch):
+    """Patch vision_process.io with the fake module for every test."""
+    import qwen_vl_utils.vision_process as vp
+
+    fake = _make_fake_torchvision_io()
+    monkeypatch.setattr(vp, "io", fake)
+
+
+def _run(ele):
+    import qwen_vl_utils.vision_process as vp
+
+    return vp._read_video_torchvision(ele)
+
+
+def test_no_trim_indices_start_at_zero(_patch_io):
+    """Without video_start, indices should start at 0."""
+    _, meta, _ = _run({"video": "fake.mp4"})
+    assert meta["frames_indices"][0] == 0
+
+
+def test_video_start_offset_indices(_patch_io):
+    """video_start=2.0 at 25fps -> first index is 50."""
+    _, meta, _ = _run({"video": "fake.mp4", "video_start": 2.0})
+    assert meta["frames_indices"][0] == 50
+
+
+def test_video_start_end_offset_indices(_patch_io):
+    """video_start=1.0 video_end=3.0 at 25fps -> first index 25, total_num_frames 50."""
+    _, meta, _ = _run({"video": "fake.mp4", "video_start": 1.0, "video_end": 3.0})
+    assert meta["frames_indices"][0] == 25
+    assert meta["total_num_frames"] == 50


### PR DESCRIPTION
Fixes #2085

This PR makes `qwen_vl_utils` report absolute `frames_indices` for the torchvision video backend when `video_start` is set.

`torchvision.io.read_video` returns frames from the clipped segment requested by `start_pts` / `end_pts`, so the sampled indices are relative to that segment. The decord and torchcodec backends already report indices in the original video timeline. This change adds the `video_start` frame offset back to the torchvision indices so the metadata is consistent across backends.

I also added a focused regression test with a mocked `torchvision.io.read_video` path for:

- no trim, where indices still start at 0
- `video_start=2.0` at 25 fps, where the first index is 50
- `video_start=1.0` / `video_end=3.0`, where the first index is 25 and the clipped frame count is preserved

Validation:

- `D:/Dev/conda-envs/py313/python.exe -m pytest tests/test_torchvision_frame_indices.py -v`
- `D:/Dev/conda-envs/py313/python.exe -m ruff check tests/test_torchvision_frame_indices.py`
- `D:/Dev/conda-envs/py313/python.exe -m ruff format --check tests/test_torchvision_frame_indices.py`
- `git diff --check`