### PR TITLE
Fix video size not updated due to SizeDict not being a dict

### DIFF
--- a/qwen-vl-finetune/qwenvl/data/data_processor.py
+++ b/qwen-vl-finetune/qwenvl/data/data_processor.py
@@ -113,7 +113,7 @@ def update_processor_pixels(processor, data_args):
             vp.fps = data_args.video_fps
             rank0_print(f"✅ Updated video_processor fps to {data_args.video_fps}")
 
-        if hasattr(vp, "size") and isinstance(vp.size, dict):
+        if hasattr(vp, "size") and hasattr(vp.size, "__setitem__"):
             vp.size["shortest_edge"] = data_args.video_min_pixels
             vp.size["longest_edge"] = data_args.video_max_pixels
             rank0_print(


### PR DESCRIPTION
## Summary
Fixes #2099.

The guard `isinstance(vp.size, dict)` in
`qwen-vl-finetune/qwenvl/data/data_processor.py` (L116) is always `False` because
`vp.size` is a `SizeDict` (not a subclass of `dict`) in recent `transformers`. As a
result the block that applies `video_min_pixels` / `video_max_pixels` to
`vp.size["shortest_edge"]` / `vp.size["longest_edge"]` is silently skipped, and the
configured video resolution has no effect.

## Fix
The original `isinstance(vp.size, dict)` check appears to be a guard ensuring the
subsequent `vp.size[...] = ...` assignment is valid. Instead of checking for a concrete
type, this PR checks for the assignment capability via duck typing, which works for both
a plain `dict` and a `SizeDict`:

```diff
-        if hasattr(vp, "size") and isinstance(vp.size, dict):
+        if hasattr(vp, "size") and hasattr(vp.size, "__setitem__"):
             vp.size["shortest_edge"] = data_args.video_min_pixels
             vp.size["longest_edge"] = data_args.video_max_pixels
```

I considered `isinstance(vp.size, SizeDict)`, but `SizeDict` is an internal
`transformers` class whose import path has changed across versions, so checking for
`__setitem__` avoids a version-dependent import. This is also consistent with the
surrounding code, which already calls `vp.size.get(...)` without any type check.

## Testing
- transformers 4.57.0, commit `96588727e44c78b25ba03ea03b8e12f7e64fd0da`
- Before: the `✅ Updated Video size (shortest_edge / longest_edge)` log lines are not
  printed and the configured pixel size is not applied.
- After: the log lines are printed and `vp.size` reflects the configured
  `video_min_pixels` / `video_max_pixels`.