### PR TITLE
fix(qwen-vl-utils): point project URLs to Qwen3-VL

### DIFF
--- a/qwen-vl-utils/pyproject.toml
+++ b/qwen-vl-utils/pyproject.toml
@@ -28,9 +28,9 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/QwenLM/Qwen2-VL/tree/main/qwen-vl-utils"
-Repository = "https://github.com/QwenLM/Qwen2-VL.git"
-Issues = "https://github.com/QwenLM/Qwen2-VL/issues"
+Homepage = "https://github.com/QwenLM/Qwen3-VL/tree/main/qwen-vl-utils"
+Repository = "https://github.com/QwenLM/Qwen3-VL.git"
+Issues = "https://github.com/QwenLM/Qwen3-VL/issues"
 
 [project.optional-dependencies]
 decord = [


### PR DESCRIPTION
## Summary

The `qwen-vl-utils` project metadata still points to the Qwen2-VL repository.

This updates the Homepage, Repository, and Issues URLs to Qwen3-VL.

## Test plan

- Verified the updated URL values.
- Ran `git diff --check`.