### PR TITLE
Honor configured model_max_length in finetune collation

### DIFF
--- a/qwen-vl-finetune/qwenvl/data/data_processor.py
+++ b/qwen-vl-finetune/qwenvl/data/data_processor.py
@@ -675,15 +675,20 @@ class FlattenedDataCollatorForSupervisedDataset(DataCollatorForSupervisedDataset
         return batch
 
 
-def make_supervised_data_module(processor, data_args) -> Dict:
+def make_supervised_data_module(
+    processor,
+    data_args,
+    tokenizer: Optional[transformers.PreTrainedTokenizerBase] = None,
+) -> Dict:
     """Make dataset and collator for supervised fine-tuning."""
     train_dataset = LazySupervisedDataset(processor, data_args=data_args)
+    collator_tokenizer = tokenizer if tokenizer is not None else processor.tokenizer
     if data_args.data_flatten or data_args.data_packing:
-        data_collator = FlattenedDataCollatorForSupervisedDataset(processor.tokenizer)
+        data_collator = FlattenedDataCollatorForSupervisedDataset(collator_tokenizer)
         return dict(
             train_dataset=train_dataset, eval_dataset=None, data_collator=data_collator
         )
-    data_collator = DataCollatorForSupervisedDataset(processor.tokenizer)
+    data_collator = DataCollatorForSupervisedDataset(collator_tokenizer)
     return dict(
         train_dataset=train_dataset, eval_dataset=None, data_collator=data_collator
     )

--- a/qwen-vl-finetune/qwenvl/train/train_qwen.py
+++ b/qwen-vl-finetune/qwenvl/train/train_qwen.py
@@ -183,7 +183,9 @@ def train(attn_implementation="flash_attention_2"):
             model.visual.print_trainable_parameters()
             model.model.print_trainable_parameters()
     
-    data_module = make_supervised_data_module(processor, data_args=data_args)
+    data_module = make_supervised_data_module(
+        processor, data_args=data_args, tokenizer=tokenizer
+    )
     trainer = Trainer(
         model=model, processing_class=tokenizer, args=training_args, **data_module
     )

--- a/qwen-vl-finetune/tests/test_data_module.py
+++ b/qwen-vl-finetune/tests/test_data_module.py
@@ -1,0 +1,63 @@
+import ast
+import importlib
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+
+FINETUNE_ROOT = Path(__file__).parents[1]
+sys.path.insert(0, str(FINETUNE_ROOT))
+data_processor = importlib.import_module("qwenvl.data.data_processor")
+
+
+class DataModuleTokenizerTests(unittest.TestCase):
+    def test_collator_uses_training_tokenizer_max_length(self):
+        processor_tokenizer = SimpleNamespace(pad_token_id=0, model_max_length=32)
+        training_tokenizer = SimpleNamespace(pad_token_id=0, model_max_length=3)
+        processor = SimpleNamespace(tokenizer=processor_tokenizer)
+        data_args = SimpleNamespace(data_flatten=False, data_packing=False)
+
+        with mock.patch.object(data_processor, "LazySupervisedDataset", return_value=object()):
+            data_module = data_processor.make_supervised_data_module(
+                processor,
+                data_args,
+                tokenizer=training_tokenizer,
+            )
+
+        instance = {
+            "input_ids": torch.tensor([[1, 2, 3, 4, 5]]),
+            "labels": torch.tensor([[1, 2, 3, 4, 5]]),
+            "position_ids": torch.arange(5).view(1, 1, 5).expand(3, 1, 5),
+        }
+        batch = data_module["data_collator"]([instance])
+
+        self.assertIs(data_module["data_collator"].tokenizer, training_tokenizer)
+        self.assertEqual(batch["input_ids"].shape, (1, 3))
+        self.assertEqual(batch["labels"].shape, (1, 3))
+        self.assertEqual(batch["position_ids"].shape, (3, 1, 3))
+
+    def test_training_entrypoint_forwards_configured_tokenizer(self):
+        train_path = FINETUNE_ROOT / "qwenvl" / "train" / "train_qwen.py"
+        tree = ast.parse(train_path.read_text(encoding="utf-8"))
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "make_supervised_data_module"
+        ]
+
+        self.assertEqual(len(calls), 1)
+        tokenizer_keyword = next(
+            keyword for keyword in calls[0].keywords if keyword.arg == "tokenizer"
+        )
+        self.assertIsInstance(tokenizer_keyword.value, ast.Name)
+        self.assertEqual(tokenizer_keyword.value.id, "tokenizer")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- pass the tokenizer configured by TrainingArguments into the supervised data module
- construct both collator variants with that tokenizer
- retain the processor tokenizer as a backward-compatible fallback for other callers
- add regression coverage for token, label, and 3D RoPE position-id truncation

## Problem

The training entrypoint creates two distinct tokenizer objects:

1. AutoProcessor supplies processor.tokenizer with the model's default maximum length.
2. AutoTokenizer is loaded with the user-provided model_max_length and is passed to Trainer.

The data module previously built its collator from processor.tokenizer, so collation happened before Trainer with the wrong length limit. A direct reproduction with Qwen/Qwen3-VL-4B-Instruct and model_max_length=8192 produced:

- processor.tokenizer.model_max_length: 262144
- training tokenizer.model_max_length: 8192
- same object: false

Consequently, standard batched fine-tuning could silently ignore the configured limit when truncating input_ids, labels, and multimodal position_ids.

## Tests

- python -m pytest qwen-vl-finetune/tests/test_data_module.py -q
- python -m unittest discover -s qwen-vl-finetune/tests -p test_data_module.py -v
- Linux Python 3.10, PyTorch 2.5.1, Transformers 4.57.6: 2 tests passed
- python -m compileall -q qwen-vl-finetune/qwenvl/data/data_processor.py qwen-vl-finetune/qwenvl/train/train_qwen.py qwen-vl-finetune/tests/test_data_module.py