### PR TITLE
Apply configured video pixel limits with SizeDict

### DIFF
--- a/qwen-vl-finetune/qwenvl/data/data_processor.py
+++ b/qwen-vl-finetune/qwenvl/data/data_processor.py
@@ -4,7 +4,7 @@ import logging
 import re
 import time
 import itertools
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, is_dataclass, replace
 from typing import Dict, Optional, Sequence, List, Tuple, Any
 from collections.abc import Sequence
 from pathlib import Path
@@ -41,6 +41,36 @@ def _make_abs_paths(base: Path, files: str) -> str:
     return f"{(base / files).resolve()}"
 
 
+def _get_size_value(size, key):
+    if isinstance(size, dict):
+        return size.get(key, "N/A")
+    return getattr(size, key, "N/A")
+
+
+def _update_processor_size(processor, shortest_edge, longest_edge):
+    size = getattr(processor, "size", None)
+    if size is None:
+        return False
+
+    if is_dataclass(size):
+        try:
+            processor.size = replace(
+                size,
+                shortest_edge=shortest_edge,
+                longest_edge=longest_edge,
+            )
+            return True
+        except (TypeError, ValueError):
+            return False
+
+    try:
+        size["shortest_edge"] = shortest_edge
+        size["longest_edge"] = longest_edge
+    except (AttributeError, TypeError):
+        return False
+    return True
+
+
 def update_processor_pixels(processor, data_args):
     logger = logging.getLogger(__name__)
 
@@ -50,8 +80,12 @@ def update_processor_pixels(processor, data_args):
     rank0_print(f"Image min_pixels: {getattr(ip, 'min_pixels', 'N/A')}")
     rank0_print(f"Image max_pixels: {getattr(ip, 'max_pixels', 'N/A')}")
     rank0_print(f"ip.size: {ip.size}")
-    rank0_print(f"Image size (shortest_edge): {ip.size.get('shortest_edge', 'N/A')}")
-    rank0_print(f"Image size (longest_edge):  {ip.size.get('longest_edge', 'N/A')}")
+    rank0_print(
+        f"Image size (shortest_edge): {_get_size_value(ip.size, 'shortest_edge')}"
+    )
+    rank0_print(
+        f"Image size (longest_edge):  {_get_size_value(ip.size, 'longest_edge')}"
+    )
 
     if hasattr(ip, "min_pixels") and hasattr(ip, "max_pixels"):
         ip.min_pixels = data_args.min_pixels
@@ -59,9 +93,7 @@ def update_processor_pixels(processor, data_args):
         rank0_print(f"✅ Updated image_processor min_pixels to {data_args.min_pixels}")
         rank0_print(f"✅ Updated image_processor max_pixels to {data_args.max_pixels}")
 
-    if hasattr(ip, "size") and isinstance(ip.size, dict):
-        ip.size["shortest_edge"] = data_args.min_pixels
-        ip.size["longest_edge"] = data_args.max_pixels
+    if _update_processor_size(ip, data_args.min_pixels, data_args.max_pixels):
         rank0_print(
             f"✅ Updated image_processor size['shortest_edge'] to {data_args.min_pixels}"
         )
@@ -72,8 +104,12 @@ def update_processor_pixels(processor, data_args):
     rank0_print("=== AFTER IMAGE PROCESSOR PARAMETERS ===")
     rank0_print(f"Image min_pixels: {getattr(ip, 'min_pixels', 'N/A')}")
     rank0_print(f"Image max_pixels: {getattr(ip, 'max_pixels', 'N/A')}")
-    rank0_print(f"Image size (shortest_edge): {ip.size.get('shortest_edge', 'N/A')}")
-    rank0_print(f"Image size (longest_edge):  {ip.size.get('longest_edge', 'N/A')}")
+    rank0_print(
+        f"Image size (shortest_edge): {_get_size_value(ip.size, 'shortest_edge')}"
+    )
+    rank0_print(
+        f"Image size (longest_edge):  {_get_size_value(ip.size, 'longest_edge')}"
+    )
 
     # --- Video Processor ---
     if hasattr(processor, "video_processor") and processor.video_processor is not None:
@@ -85,9 +121,11 @@ def update_processor_pixels(processor, data_args):
         rank0_print(f"Video max_frames: {getattr(vp, 'max_frames', 'N/A')}")
         rank0_print(f"Video fps: {getattr(vp, 'fps', 'N/A')}")
         rank0_print(
-            f"Video size (shortest_edge): {vp.size.get('shortest_edge', 'N/A')}"
+            f"Video size (shortest_edge): {_get_size_value(vp.size, 'shortest_edge')}"
         )
-        rank0_print(f"Video size (longest_edge):  {vp.size.get('longest_edge', 'N/A')}")
+        rank0_print(
+            f"Video size (longest_edge):  {_get_size_value(vp.size, 'longest_edge')}"
+        )
 
         if hasattr(vp, "min_pixels") and hasattr(vp, "max_pixels"):
             vp.min_pixels = data_args.video_min_pixels
@@ -113,14 +151,16 @@ def update_processor_pixels(processor, data_args):
             vp.fps = data_args.video_fps
             rank0_print(f"✅ Updated video_processor fps to {data_args.video_fps}")
 
-        if hasattr(vp, "size") and isinstance(vp.size, dict):
-            vp.size["shortest_edge"] = data_args.video_min_pixels
-            vp.size["longest_edge"] = data_args.video_max_pixels
+        if _update_processor_size(
+            vp, data_args.video_min_pixels, data_args.video_max_pixels
+        ):
             rank0_print(
-                f"✅ Updated Video size (shortest_edge): {vp.size.get('shortest_edge', 'N/A')}"
+                "✅ Updated Video size (shortest_edge): "
+                f"{_get_size_value(vp.size, 'shortest_edge')}"
             )
             rank0_print(
-                f"✅ Updated Video size (longest_edge):  {vp.size.get('longest_edge', 'N/A')}"
+                "✅ Updated Video size (longest_edge):  "
+                f"{_get_size_value(vp.size, 'longest_edge')}"
             )
 
         rank0_print("=== AFTER VIDEO PROCESSOR PARAMETERS ===")
@@ -130,9 +170,11 @@ def update_processor_pixels(processor, data_args):
         rank0_print(f"Video max_frames: {getattr(vp, 'max_frames', 'N/A')}")
         rank0_print(f"Video fps: {getattr(vp, 'fps', 'N/A')}")
         rank0_print(
-            f"Video size (shortest_edge): {vp.size.get('shortest_edge', 'N/A')}"
+            f"Video size (shortest_edge): {_get_size_value(vp.size, 'shortest_edge')}"
         )
-        rank0_print(f"Video size (longest_edge):  {vp.size.get('longest_edge', 'N/A')}")
+        rank0_print(
+            f"Video size (longest_edge):  {_get_size_value(vp.size, 'longest_edge')}"
+        )
 
     return processor
 

--- a/qwen-vl-finetune/tests/test_processor_pixels.py
+++ b/qwen-vl-finetune/tests/test_processor_pixels.py
@@ -1,0 +1,64 @@
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from transformers.image_utils import SizeDict
+
+
+FINETUNE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(FINETUNE_ROOT))
+
+from qwenvl.data.data_processor import update_processor_pixels  # noqa: E402
+
+
+class ProcessorPixelsTest(unittest.TestCase):
+    def test_updates_frozen_video_size_dict(self):
+        image_size = {"shortest_edge": 16, "longest_edge": 32}
+        video_size = SizeDict(
+            shortest_edge=64,
+            longest_edge=128,
+            max_height=720,
+            max_width=1280,
+        )
+        processor = SimpleNamespace(
+            image_processor=SimpleNamespace(
+                min_pixels=16,
+                max_pixels=32,
+                size=image_size,
+            ),
+            video_processor=SimpleNamespace(
+                min_pixels=64,
+                max_pixels=128,
+                min_frames=4,
+                max_frames=8,
+                fps=1.0,
+                size=video_size,
+            ),
+        )
+        data_args = SimpleNamespace(
+            min_pixels=256,
+            max_pixels=512,
+            video_min_pixels=1024,
+            video_max_pixels=2048,
+            video_min_frames=8,
+            video_max_frames=32,
+            video_fps=2.0,
+        )
+
+        result = update_processor_pixels(processor, data_args)
+
+        self.assertIs(result, processor)
+        self.assertEqual(
+            processor.image_processor.size,
+            {"shortest_edge": 256, "longest_edge": 512},
+        )
+        self.assertIsNot(processor.video_processor.size, video_size)
+        self.assertEqual(processor.video_processor.size.shortest_edge, 1024)
+        self.assertEqual(processor.video_processor.size.longest_edge, 2048)
+        self.assertEqual(processor.video_processor.size.max_height, 720)
+        self.assertEqual(processor.video_processor.size.max_width, 1280)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- apply configured image/video pixel limits when processor.size is either a mutable mapping or Transformers' frozen SizeDict
- read size diagnostics from both representations
- add a CPU regression test using the real transformers.image_utils.SizeDict

## Problem

The fine-tuning path only updates size when it is a plain dict. In Transformers 4.57, SizeDict is a frozen dataclass: it is not a dict, has no get method, and does not support item assignment. Consequently, the diagnostic reads can fail and video_min_pixels / video_max_pixels are not applied.

## Fix

Mutable mapping-like size objects retain the existing in-place update. Dataclass-backed size objects are rebuilt with dataclasses.replace, which preserves fields such as max_height and max_width while changing only shortest_edge and longest_edge.

The same helper is used for the image and video processors so the two paths stay consistent.

## Validation

- regression on current main: AttributeError because SizeDict has no get method
- python -B -m unittest discover -s qwen-vl-finetune/tests -p "test_*.py" -v (1 passed)
- Ruff checks pass for the new test and changed path, excluding unrelated pre-existing findings in the legacy source file
- git diff --check

Closes #2099

## Relation to prior PR #2103

PR #2103 identified the same failing concrete-type guard, but it changed the condition to require __setitem__. In Transformers 4.57, SizeDict is a frozen dataclass and does not support mapping assignment, so that guard still does not apply the configured limits; #2103 was closed without merge.

This PR instead rebuilds the frozen SizeDict with dataclasses.replace, preserves its other fields, applies the same logic to both image and video processors, and tests the real transformers.image_utils.SizeDict type.
