### PR TITLE
[doc] video timestamps for pre-sampled frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,68 @@ print(output_text)
 </details>
 
 <details>
+<summary>Pre-sampled Frames and Timestamps</summary>
+
+Qwen3-VL inserts a `<{t:.1f} seconds>` marker before every temporal patch. A temporal patch spans `merge_size = 2` frames and its marker is the mean of the two frame times, so 8 frames produce 4 markers rather than 8.
+
+Each frame time is `frames_indices[i] / fps`, and both values come from the video metadata. When `video` is a local path or a url, `qwen-vl-utils` reads them from the file. When `video` is a frame list it cannot, so it returns a placeholder in which `frames_indices` is `range(n)` over the frame count and the frame rate comes from `sample_fps` (default `2.0`). Passing that placeholder through unchanged gives evenly spaced timestamps whatever frames were actually selected, and nothing is raised or logged.
+
+For frames extracted at a constant rate, set `sample_fps` to that rate, as in the frame-list example above. For frames chosen at uneven intervals (random sampling, keyframe selection), `sample_fps` cannot describe the spacing, so replace the returned metadata with the source video's own values:
+
+```python
+# continuing from the Process Videos example above
+from torchcodec.decoders import VideoDecoder
+from PIL import Image
+
+decoder = VideoDecoder("/path/to/video1.mp4")
+total_num_frames = decoder.metadata.num_frames
+source_fps = float(decoder.metadata.average_fps)
+
+# any selection of frame indices, evenly spaced or not
+frames_indices = [38, 69, 102, 200, 208, 243, 246, 335]
+frames = [
+    Image.fromarray(f.permute(1, 2, 0).numpy())
+    for f in decoder.get_frames_at(indices=frames_indices).data
+]
+
+messages = [
+    {
+        "role": "user",
+        "content": [
+            {"type": "video", "video": frames},
+            {"type": "text", "text": "Describe this video."},
+        ],
+    }
+]
+
+text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+images, videos, video_kwargs = process_vision_info(messages, image_patch_size=16, return_video_kwargs=True, return_video_metadata=True)
+
+# drop the placeholder metadata and pass the source video's own values instead
+if videos is not None:
+    videos, _ = zip(*videos)
+    videos = list(videos)
+video_metadatas = [
+    {"fps": source_fps, "frames_indices": frames_indices, "total_num_frames": total_num_frames}
+]
+
+inputs = processor(text=text, images=images, videos=videos, video_metadata=video_metadatas, return_tensors="pt", do_resize=False, **video_kwargs)
+inputs = inputs.to(model.device)
+```
+
+📌 Note:
+
+- `return_video_metadata=True` alone is not enough for a frame list. The metadata it returns has to be replaced, otherwise two different selections of the same number of frames produce identical timestamps.
+- The values do not have to come from the file. Any consistent pair works, as long as `frames_indices[i] / fps` is the timestamp you want in seconds. `total_num_frames` is required but does not affect the markers.
+- If `video_metadata` is omitted, the processor falls back to `fps=24` and logs a warning. It is printed only once per process, so it is easy to miss in a long run.
+- Keep `**video_kwargs`: it carries `do_sample_frames=False`, without which the processor samples the already-sampled frames again.
+- `sample_fps` must be a number, and is ignored when `video` is a path or a url.
+- A frame list is padded to an even length by repeating the last frame, so the processed video may contain one more frame than was passed in.
+
+</details>
+
+
+<details>
 <summary>Video Backends and URL Compatibility</summary>
 
 Currently, `qwen-vl-utils` supports three video decoding backends: `torchvision`, `decord`, and `torchcodec`. While `decord` and `torchcodec` generally offer significantly faster decoding speeds compared to `torchvision`, we recommend using `torchcodec`. This is because `decord` has known issues, such as decoding hangs, and its project is no longer actively maintained.

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ messages = [
                     "file:///path/to/frame3.jpg",
                     "file:///path/to/frame4.jpg",
                 ],
-                'sample_fps':'1', # sample_fps: frame sampling rate (frames per second), used to determine timestamps for each frame
+                "sample_fps": 1.0, # frame sampling rate (frames per second), used to determine the timestamp of each frame. See "Pre-sampled Frames and Timestamps" below if the frames are not evenly spaced.
             },
             {"type": "text", "text": "Describe this video."},
         ],

--- a/README.md
+++ b/README.md
@@ -700,7 +700,7 @@ messages = [
 ]
 
 text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
-images, videos, video_kwargs = process_vision_info(messages, image_patch_size=16, return_video_kwargs=True, return_video_metadata=True)
+images, videos, video_kwargs = process_vision_info(messages, image_patch_size=processor.image_processor.patch_size, return_video_kwargs=True, return_video_metadata=True)
 
 # drop the placeholder metadata and pass the source video's own values instead
 if videos is not None:

--- a/README.md
+++ b/README.md
@@ -725,7 +725,6 @@ inputs = inputs.to(model.device)
 
 </details>
 
-
 <details>
 <summary>Video Backends and URL Compatibility</summary>
 

--- a/qwen-vl-utils/README.md
+++ b/qwen-vl-utils/README.md
@@ -116,7 +116,7 @@ messages = [
     ## Local video path
     [{"role": "user", "content": [{"type": "video", "video": "file:///path/to/video1.mp4"}, {"type": "text", "text": "Describe this video."}]}],
     ## Local video frames
-    [{"role": "user", "content": [{"type": "video", "video": ["file:///path/to/extracted_frame1.jpg", "file:///path/to/extracted_frame2.jpg", "file:///path/to/extracted_frame3.jpg"],}, {"type": "text", "text": "Describe this video."},],}],
+    [{"role": "user", "content": [{"type": "video", "video": ["file:///path/to/extracted_frame1.jpg", "file:///path/to/extracted_frame2.jpg", "file:///path/to/extracted_frame3.jpg"], "sample_fps": 1.0,}, {"type": "text", "text": "Describe this video."},],}],
     ## Model dynamically adjusts video nframes, video height and width. specify args if required.
     [{"role": "user", "content": [{"type": "video", "video": "file:///path/to/video1.mp4", "fps": 2.0, "resized_height": 280, "resized_width": 280}, {"type": "text", "text": "Describe this video."}]}],
 ]


### PR DESCRIPTION
### What

`Process Videos` documents `sample_fps` for the images-list input, but not what happens to
timestamps when the frames are not evenly spaced. This adds a short section covering both
cases, and makes `sample_fps` a numeric literal in the existing examples.

### Why

Qwen3-VL inserts a `<{t:.1f} seconds>` marker before every temporal patch, derived from the
video metadata. For a path or a url, `qwen-vl-utils` reads the frame rate and the sampled
frame indices from the file. For a frame list there is no file to read, so the metadata it
returns has `frames_indices = range(n)`.

On a 380-frame / 30 fps clip, 8 selected frames (4 temporal patches, so 4 markers):

| metadata passed to the processor | markers |
| --- | --- |
| returned metadata, unchanged — uniform selection | `<0.2 seconds> <1.2 seconds> <2.2 seconds> <3.2 seconds>` |
| returned metadata, unchanged — random selection | `<0.2 seconds> <1.2 seconds> <2.2 seconds> <3.2 seconds>` |
| `video_metadata` omitted | `<0.0 seconds> <0.1 seconds> <0.2 seconds> <0.3 seconds>` |
| source `fps` + `frames_indices` — uniform | `<0.9 seconds> <4.5 seconds> <8.1 seconds> <11.7 seconds>` |
| source `fps` + `frames_indices` — random | `<1.8 seconds> <5.0 seconds> <7.5 seconds> <9.7 seconds>` |

In the first two rows the two selections are indistinguishable to the model, and nothing is
raised or logged. For a downstream data point, lmms-eval measured VSI-Bench at 32 frames
going from 0.5092 to 0.3983 purely from omitting this metadata (lmms-eval issues 1244/1248).

The offline-inference examples already show this call shape, but with a video path, where
`qwen-vl-utils` fills the metadata in correctly. The frame-list case needs the returned
metadata replaced rather than passed through.

### Changes

- `README.md`: new `Pre-sampled Frames and Timestamps` section — `sample_fps` for frames
  extracted at a constant rate, and replacing the returned metadata with the source video's
  `fps` and `frames_indices` for unevenly spaced selections.
- `README.md`: `'sample_fps':'1'` to `"sample_fps": 1.0` in the frame-list example.
  `fetch_video` computes `total_num_frames` as `(nframes / sample_fps) * raw_fps`, so the
  quoted value raises `TypeError` when that block is used as written. The comment now also
  points at the new section.
- `qwen-vl-utils/README.md`: add `sample_fps` to the Qwen3VL local-video-frames example,
  which currently omits it.

Verified against `qwen-vl-utils` 0.0.14 and `transformers` 4.57.1; the example in the new
section runs as written. Scoped to the `transformers` + `qwen-vl-utils` path — the vLLM
frame-list path and the resize behaviour on this path are separate.

Refs #1992

Alternative: add a warning in
`qwen-vl-utils` when a frame list is passed without `sample_fps`, if a code change is preferred instead.
