### PR TITLE
Fix stale qwen-vl-utils project links

### DIFF
--- a/qwen-vl-utils/pyproject.toml
+++ b/qwen-vl-utils/pyproject.toml
@@ -28,9 +28,9 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/QwenLM/Qwen2-VL/tree/main/qwen-vl-utils"
-Repository = "https://github.com/QwenLM/Qwen2-VL.git"
-Issues = "https://github.com/QwenLM/Qwen2-VL/issues"
+Homepage = "https://github.com/QwenLM/Qwen3-VL/tree/main/qwen-vl-utils"
+Repository = "https://github.com/QwenLM/Qwen3-VL.git"
+Issues = "https://github.com/QwenLM/Qwen3-VL/issues"
 
 [project.optional-dependencies]
 decord = [


### PR DESCRIPTION
## Summary
- Update the stale Homepage, Repository, and Issues links in qwen-vl-utils/pyproject.toml from Qwen2-VL to Qwen3-VL.
- Keep the package version and runtime behavior unchanged.

Fixes #2109

## Testing
- TOML parsing and exact project URL assertions: passed.
- `python -m build --sdist --wheel`: passed.
- Wheel and sdist Project-URL metadata checks: passed.
- AST parsing of qwen-vl-utils Python sources: passed.
- `git diff --check`: passed.
- Gitleaks scan of qwen-vl-utils: passed.
- No qwen-vl-utils test files are present in the repository.
- Ruff check/format check report pre-existing issues in the unchanged vision_process.py; this PR does not modify that file.

No model weights, inference code, or business integrations are included.